### PR TITLE
Added Ammo to Mark

### DIFF
--- a/Wrath of Cthulhu/Assets/Animations/Attack_DeepOnes.anim
+++ b/Wrath of Cthulhu/Assets/Animations/Attack_DeepOnes.anim
@@ -87,14 +87,14 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_GenerateMotionCurves: 0
   m_Events:
-  - time: 0.75
+  - time: 0.4
     functionName: meleeAttack
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 0.93333334
+  - time: 0.7
     functionName: stopMeleeAttack
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Wrath of Cthulhu/Assets/Animations/Damage_Mark.anim
+++ b/Wrath of Cthulhu/Assets/Animations/Damage_Mark.anim
@@ -73,10 +73,3 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 0.016666668
-    functionName: PlayGrunt
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0

--- a/Wrath of Cthulhu/Assets/Prefabs/Enemy.prefab
+++ b/Wrath of Cthulhu/Assets/Prefabs/Enemy.prefab
@@ -231,6 +231,7 @@ MonoBehaviour:
   dashTimer: 0
   maxDash: 1
   savedVelocity: {x: 0, y: 0}
+  randomNumber: 0
   items:
   - {fileID: 1627987009531400, guid: 2bb48ddf63ba4204e965337588ebb48f, type: 2}
   - {fileID: 1170061375301152, guid: 1da3534cca72f404198ca461d9a80d43, type: 2}
@@ -238,7 +239,7 @@ MonoBehaviour:
   idle: 0
   attackMark: 0
   controlMeleeCollision: 0
-  speed: 1
+  speed: 0.75
   maxSpeed: 0.01
   health: 0
   enemyCount: 10

--- a/Wrath of Cthulhu/Assets/Prefabs/RangedEnemy.prefab
+++ b/Wrath of Cthulhu/Assets/Prefabs/RangedEnemy.prefab
@@ -190,7 +190,7 @@ MonoBehaviour:
   idle: 0
   attackMark: 0
   controlMeleeCollision: 0
-  speed: 1
+  speed: 0.75
   maxSpeed: 0.01
   health: 0
   enemyCount: 10

--- a/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
@@ -1076,7 +1076,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c97b45ec42df45f6b014fc121fa2324, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  count: 99
+  count: 0
 --- !u!114 &1804639604
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
@@ -948,6 +948,93 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1734079057}
+--- !u!1 &1736242071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1736242072}
+  - component: {fileID: 1736242074}
+  - component: {fileID: 1736242073}
+  - component: {fileID: 1736242075}
+  m_Layer: 5
+  m_Name: AmmoCount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1736242072
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1736242071}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.41666472, y: 0.41666472, z: 0.41666472}
+  m_Children: []
+  m_Father: {fileID: 1871221487}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 327.1, y: -205.41669}
+  m_SizeDelta: {x: 255.9, y: 96.6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1736242073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1736242071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.99215686, g: 0.81960785, b: 0.3019608, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: ad453e256fddac64f83c2c4295bc6a15, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1736242074
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1736242071}
+--- !u!114 &1736242075
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1736242071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c3cc1d19ff790b4fa137c46b7349fbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  countAmmo: 0
 --- !u!1 &1793191951
 GameObject:
   m_ObjectHideFlags: 0
@@ -1149,6 +1236,7 @@ RectTransform:
   - {fileID: 1793191952}
   - {fileID: 878546755}
   - {fileID: 1804639602}
+  - {fileID: 1736242072}
   m_Father: {fileID: 642324221}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
@@ -333,6 +333,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -974,6 +988,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -2740,6 +2768,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -3153,6 +3195,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -3440,6 +3496,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -3659,6 +3729,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -4197,6 +4281,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -4418,7 +4516,6 @@ MonoBehaviour:
   minCameraPosX: 0
   maxCameraPosX: 0
   CameraFollow: {fileID: 0}
-  currency: 0
   bullet: {fileID: 1611821028136744, guid: c54433a8189ddf74a82616b18153d612, type: 2}
   bulletDamage: 0
   spawnPoint: {fileID: 408186884}
@@ -4441,9 +4538,12 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 27968b56122c6f247a915b2f3f60a560, type: 2}
   - {fileID: 11400000, guid: 3681979a1cbb85c4aa0327c15f98383a, type: 2}
   - {fileID: 11400000, guid: 87b3e14342703aa47990115fe8840afd, type: 2}
-  currentWeapon: 0
+  latestBuy: 0
   gameOverPanel: {fileID: 529114139}
   gameAudio: {fileID: 1883274627}
+  elixir: 0
+  blink: 0
+  morphine: 0
   pausePanel: {fileID: 947615096}
   enterShopUIPanel: {fileID: 1414628194}
   shopPanel: {fileID: 1916252800}
@@ -5122,6 +5222,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -5797,6 +5911,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -6114,6 +6242,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -6556,6 +6698,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -6827,6 +6983,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -7493,6 +7663,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -7959,6 +8143,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -8039,6 +8237,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -9845,6 +10057,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -11327,6 +11553,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -12785,8 +13025,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Story goes here...
-
+  m_Text: '
 
 
     Controls:
@@ -13017,6 +13256,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -14343,6 +14596,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -14707,6 +14974,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -16647,6 +16928,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -16718,6 +17013,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -17106,6 +17415,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -17674,6 +17997,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -18618,6 +18955,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -21546,6 +21897,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -22112,6 +22477,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -22715,6 +23094,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -22800,6 +23193,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -25424,6 +25831,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -25868,6 +26289,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -26238,6 +26673,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -26290,6 +26739,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -27094,6 +27557,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -27893,6 +28370,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -28923,6 +29414,20 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0

--- a/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
@@ -4548,6 +4548,7 @@ MonoBehaviour:
   enterShopUIPanel: {fileID: 1414628194}
   shopPanel: {fileID: 1916252800}
   gamePlayPanel: {fileID: 1356524129}
+  scrollBar: {fileID: 787893316}
   upgradeDamage: 0
 --- !u!61 &291277041
 BoxCollider2D:
@@ -26565,6 +26566,16 @@ Prefab:
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
       value: Enemy (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114210506616646348, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: maxSpeed
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 114210506616646348, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: speed
+      value: 0.75
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0760493300801564db7cf9489e71b661, type: 2}

--- a/Wrath of Cthulhu/Assets/Scripts/BulletFire.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/BulletFire.cs
@@ -115,6 +115,7 @@ public class BulletFire : MonoBehaviour
             case "Player":
                 target.gameObject.GetComponent<Player>().playerHealth -= enemyDamage;
                 target.gameObject.GetComponent<Player>().playerMadness += enemyMadness;
+                controlscript.sounds[1].Play();
                 target.gameObject.GetComponent<Animator>().SetBool("Hit", true);
                 Destroy(gameObject);
                 break;

--- a/Wrath of Cthulhu/Assets/Scripts/EnemyMove.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/EnemyMove.cs
@@ -46,8 +46,8 @@ public class EnemyMove : MonoBehaviour {
     public bool controlMeleeCollision;
 
     //Enemy Attributes
-    public float speed = 1f;
-    public float maxSpeed = .01f;
+    public float speed;
+    public float maxSpeed;
     public float health;
     public float enemyCount = 10f;
     public bool enemyShooting;
@@ -73,6 +73,8 @@ public class EnemyMove : MonoBehaviour {
         attackMark = false;
         controlMeleeCollision = false;
         controlDashCollision = false;
+        maxSpeed = .01f;
+        speed = .75f;
         randomNumber = Random.Range(0f, 100f);
         if (randomNumber <= 20)
         {
@@ -330,8 +332,9 @@ public class EnemyMove : MonoBehaviour {
     {
         if (anim.GetCurrentAnimatorStateInfo(0).IsName("Dash_DeepOnes"))
         {
-            Player.GetComponent<Player>().playerHealth -= enemyDamage;
+            Player.GetComponent<Player>().playerHealth -= 15f;
             Player.GetComponent<Player>().playerMadness += enemyMadness;
+            controlscript.sounds[1].Play();
             Player.GetComponent<Animator>().SetBool("Hit", true);
             controlDashCollision = false;
         }
@@ -340,6 +343,7 @@ public class EnemyMove : MonoBehaviour {
         {
             Player.GetComponent<Player>().playerHealth -= enemyDamage;
             Player.GetComponent<Player>().playerMadness += enemyMadness;
+            controlscript.sounds[1].Play();
             Player.GetComponent<Animator>().SetBool("Hit", true);
             //controlMeleeCollision = false;
         }

--- a/Wrath of Cthulhu/Assets/Scripts/Player.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/Player.cs
@@ -59,7 +59,11 @@ public class Player : MonoBehaviour {
     public GameObject enterShopUIPanel;
     public GameObject shopPanel;
     public GameObject gamePlayPanel;
+    public GameObject scrollBar;
     public float upgradeDamage;
+
+    public Transform AmmoCount;
+    Ammo ammoScript;
 
 
     // Use this for initialization
@@ -78,6 +82,8 @@ public class Player : MonoBehaviour {
 		madnessscript = MadnessPercentage.GetComponent<Player1Madness>();
 		CameraFollow = GameObject.Find("Main Camera").transform;
 		camerascript = CameraFollow.GetComponent<CameraFollow>();
+        AmmoCount = GameObject.Find("AmmoCount").transform;
+        ammoScript = AmmoCount.GetComponent<Ammo>();
         maxSpeed = .5f;
         speed = 50;
 		dead = false;
@@ -110,6 +116,26 @@ public class Player : MonoBehaviour {
             Time.timeScale = 0f;
         }
 
+        if (Input.GetKey(KeyCode.Return) && pausePanel.activeSelf)
+        {
+            pausePanel.SetActive(false);
+            Time.timeScale = 1f;
+        }
+
+        if (Input.GetKey(KeyCode.Return) && enterShopUIPanel.activeSelf)
+        {
+            enterShopUIPanel.SetActive(false);
+            Time.timeScale = 1f;
+        }
+
+        if (Input.GetKey(KeyCode.Return) && shopPanel.activeSelf)
+        {
+            shopPanel.SetActive(false);
+            scrollBar.SetActive(false);
+            Time.timeScale = 1f;
+        }
+
+
         if (Input.GetKeyDown(KeyCode.P) && !gameOverPanel.activeSelf && !enterShopUIPanel.activeSelf && !shopPanel.activeSelf && !gamePlayPanel.activeSelf)
         {
             pausePanel.SetActive(true);
@@ -138,7 +164,18 @@ public class Player : MonoBehaviour {
             anim.SetFloat("Speed", Mathf.Abs(rb2d.velocity.x) + Mathf.Abs(rb2d.velocity.y));
             anim.SetBool("Shooting", false);
 
-            if (Input.GetKeyDown(KeyCode.K) && !anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark"))
+            if (Input.GetKeyDown(KeyCode.R)) //reload ammo
+            {
+                ammoScript.countAmmo = 6f;
+            }
+
+            if (Input.GetKeyDown(KeyCode.K) && !anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shotgun == true && ammoScript.countAmmo >= 3f)
+            {
+                anim.SetBool("Shooting", true);
+                shootOnce = true;
+            }
+
+            else if (Input.GetKeyDown(KeyCode.K) && !anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shotgun == false && ammoScript.countAmmo > 0f)
             {
                 anim.SetBool("Shooting", true);
                 shootOnce = true;
@@ -241,71 +278,6 @@ public class Player : MonoBehaviour {
                 }
             }
 
-			/*if (playerMadness>0)
-            {
-                locked = false;
-            }
-
-            if (locked == false)
-            {
-                switch (weapons[latestBuy].itemCode)
-                {
-                    case "elixir":
-                        {
-                            elixir = true;
-                            blink = false;
-                            morphine = false;
-                            break;
-                        }
-                    case "blink": ///work in progress
-                        {
-                            elixir = false;
-                            blink = true;
-                            morphine = false;
-                            break;
-                        }
-                    case "morphine":
-                        {
-                            playerMadness = 0;
-                            locked = true;
-                            break;
-                        }
-                    case "shotgun":
-                        {
-                            shotgun = true;
-                            break;
-                        }
-                    /*case "speed": //These are updated through the WeaponButton script so that it doesn't run in every frame from Update()
-                        {
-                            if (maxSpeed >= 1.5f)
-                            {
-                                maxSpeed = 1.5f;
-                            }
-
-                            else
-                            {
-                                maxSpeed += .25f;
-                            }
-                            break;
-                        }
-                    case "damage":
-                        {
-                            bulletDamage = 300f;
-                            break;
-                        }
-                    case "null":
-                        {
-                            //Do Nothing
-                            break;
-                        }
-                    default:
-                        break;
-
-                }
-            }*/
-
-                //elixir = false;
-
 
             if (anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shootOnce && shotgun == true)
             {
@@ -315,6 +287,7 @@ public class Player : MonoBehaviour {
                 bullet2.transform.Rotate(0f, 0f, 0f);
                 GameObject bullet3 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
                 bullet3.transform.Rotate(0f, 0f, -10f);
+                ammoScript.countAmmo -= 3f;
                 //Transform newBullet = Instantiate(bullet.transform, spawnPoint.position, Quaternion.identity) as Transform;
                 //newBullet.parent = transform;
                 markShooting = true;
@@ -324,6 +297,7 @@ public class Player : MonoBehaviour {
             else if (anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shootOnce)
 			{
                 Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
+                ammoScript.countAmmo -= 1f;
                 //Transform newBullet = Instantiate(bullet.transform, spawnPoint.position, Quaternion.identity) as Transform;
                 //newBullet.parent = transform;
                 markShooting = true;
@@ -402,11 +376,6 @@ public class Player : MonoBehaviour {
     void SetHit()
     {
         gameObject.GetComponent<Animator>().SetBool("Hit", false);
-    }
-
-    public void PlayGrunt()
-    {
-        sounds[1].Play();
     }
 
     void Destroy()

--- a/Wrath of Cthulhu/Assets/Scripts/UI-WeaponShop/GamePlay/GamePlay.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/UI-WeaponShop/GamePlay/GamePlay.cs
@@ -14,6 +14,12 @@ public class GamePlay : MonoBehaviour {
 	
 	// Update is called once per frame
 	void Update () {
+
+        if (Input.GetKey(KeyCode.Return) && gamePlayPanel.activeSelf)
+        {
+            gamePlayPanel.SetActive(false);
+            Time.timeScale = 1f;
+        }
 		
 	}
 

--- a/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class Ammo : MonoBehaviour {
+
+    public float countAmmo;
+
+    private void Start()
+    {
+        countAmmo = 6f;        
+    }
+    // Update is called once per frame
+    void Update()
+    {
+        GetComponent<Text>().text = countAmmo + " / Ammo";
+    }
+}

--- a/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs.meta
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8c3cc1d19ff790b4fa137c46b7349fbb
+timeCreated: 1509686792
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Wrath of Cthulhu/Assets/Scripts/UI/GameOver.meta
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/GameOver.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 7f0f5120c15c94705b0c66503a45b932
-folderAsset: yes
-timeCreated: 1509648414
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Wrath of Cthulhu/Assets/Scripts/UI/MainMenuManager.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/MainMenuManager.cs
@@ -8,8 +8,8 @@ public class MainMenuManager : MonoBehaviour {
 	private Animator menuAnim;
 	private CanvasGroup menuCanvasGroup;
 
-	// Use this for initialization
-	void Awake () {
+    // Use this for initialization
+    void Awake () {
 		menuAnim = GetComponent<Animator> ();
 		menuCanvasGroup = GetComponent<CanvasGroup> ();
 	}

--- a/Wrath of Cthulhu/Assets/Upgrades/Morphine.asset
+++ b/Wrath of Cthulhu/Assets/Upgrades/Morphine.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weaponName: Morphine
   itemCode: morphine
-  cost: 15
+  cost: 12
   description: 'Resets Mark''s madness '


### PR DESCRIPTION
Ammo:
* Mark starts off with 6 bullets (value can be changed later)
* Pressing R will reload ammo (until animations are created instead)
* Bullet spread reduces ammo by 3, regular reduces ammo by 1
* UI element created to display ammo count (can be improved later)

Polishing Work:
* All UI panels (except main menu) can now be closed by the Enter button 
* Enemy Dash does slightly less health damage 
* Grunt Audio is in sync now 
* Enemy Hit Frame is also in sync
* All enemies are slightly slower now
* Slightly dropped morphine price