### PR TITLE
Major Bugs fixed (see notes)

### DIFF
--- a/Wrath of Cthulhu/Assets/Prefabs/Enemy.prefab
+++ b/Wrath of Cthulhu/Assets/Prefabs/Enemy.prefab
@@ -68,8 +68,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1618293949978046}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.07, y: 5.34, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.6930938, y: -0.46200013, z: 0}
   m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_Children:
   - {fileID: 4220425589518628}
@@ -221,7 +221,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea5b292464eb9e042907b4aa551d9cab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  attackTrigger: {fileID: 61290118414823722}
+  attackTrigger: {fileID: 1369370886750716}
   mainCamera: {fileID: 0}
   camera: {fileID: 0}
   spawnPoint: {fileID: 0}

--- a/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
@@ -1299,8 +1299,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 284, y: -158}
-  m_SizeDelta: {x: 255.9, y: 96.6}
+  m_AnchoredPosition: {x: 278, y: -158}
+  m_SizeDelta: {x: 318.42, y: 96.6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1736242073
 MonoBehaviour:

--- a/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
@@ -681,7 +681,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -4927,7 +4927,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -6489,7 +6489,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 24
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -8425,7 +8425,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -9425,7 +9425,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 29
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -10639,26 +10639,6 @@ Prefab:
       propertyPath: m_Name
       value: Enemy (2)
       objectReference: {fileID: 0}
-    - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: m_Offset.y
-      value: -0.032989353
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: m_Size.y
-      value: 0.2540213
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: m_Offset.x
-      value: -0.006997779
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: m_Size.x
-      value: 0.2660173
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0760493300801564db7cf9489e71b661, type: 2}
   m_IsPrefabParent: 0
@@ -11330,7 +11310,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 31
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -13520,9 +13500,19 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114210506616646348, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: attackTrigger
+      value: 
+      objectReference: {fileID: 838074490}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0760493300801564db7cf9489e71b661, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &838074490 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1369370886750716, guid: 0760493300801564db7cf9489e71b661,
+    type: 2}
+  m_PrefabInternal: {fileID: 838074489}
 --- !u!1 &843956036
 GameObject:
   m_ObjectHideFlags: 0
@@ -16623,9 +16613,19 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114210506616646348, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: attackTrigger
+      value: 
+      objectReference: {fileID: 1074122141}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0760493300801564db7cf9489e71b661, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &1074122141 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1369370886750716, guid: 0760493300801564db7cf9489e71b661,
+    type: 2}
+  m_PrefabInternal: {fileID: 1074122140}
 --- !u!1 &1078930193
 GameObject:
   m_ObjectHideFlags: 0
@@ -17035,7 +17035,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 19
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -18710,7 +18710,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -18776,7 +18776,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 22
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -20458,7 +20458,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 16
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -23483,7 +23483,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 32
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -25120,7 +25120,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 33
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -25666,7 +25666,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 26
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name
@@ -27690,11 +27690,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -2.3600934
+      value: -2.045
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 1.6900003
+      value: 1.338
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_LocalPosition.z
@@ -27734,9 +27734,39 @@ Prefab:
       propertyPath: speed
       value: 0.75
       objectReference: {fileID: 0}
+    - target: {fileID: 114210506616646348, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: attackTrigger
+      value: 
+      objectReference: {fileID: 1833143664}
+    - target: {fileID: 61290118414823722, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: m_Offset.x
+      value: -0.06400625
+      objectReference: {fileID: 0}
+    - target: {fileID: 61290118414823722, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: m_Size.x
+      value: 0.09077995
+      objectReference: {fileID: 0}
+    - target: {fileID: 61290118414823722, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: m_Offset.y
+      value: -0.0103668
+      objectReference: {fileID: 0}
+    - target: {fileID: 61290118414823722, guid: 0760493300801564db7cf9489e71b661,
+        type: 2}
+      propertyPath: m_Size.y
+      value: 0.1001676
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0760493300801564db7cf9489e71b661, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &1833143664 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1369370886750716, guid: 0760493300801564db7cf9489e71b661,
+    type: 2}
+  m_PrefabInternal: {fileID: 1833143663}
 --- !u!1001 &1834964503
 Prefab:
   m_ObjectHideFlags: 0
@@ -30418,7 +30448,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4348969975031134, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 1618293949978046, guid: 0760493300801564db7cf9489e71b661, type: 2}
       propertyPath: m_Name
@@ -31030,7 +31060,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4162899185739794, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_RootOrder
-      value: 30
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 1958844333956588, guid: 264076073226a07449b08c733efa85d4, type: 2}
       propertyPath: m_Name

--- a/Wrath of Cthulhu/Assets/Scripts/EnemyMove.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/EnemyMove.cs
@@ -9,7 +9,7 @@ public class EnemyMove : MonoBehaviour {
     Player controlscript;
     private Animator anim;
     private Rigidbody2D rb2d;
-    public Collider2D attackTrigger;
+    public GameObject attackTrigger;
 
     //Camera
     public GameObject mainCamera;
@@ -87,7 +87,7 @@ public class EnemyMove : MonoBehaviour {
 
         }
         anim.SetBool("Idle", true);
-        attackTrigger.enabled = false;
+        attackTrigger.SetActive(false);
         
 
     }
@@ -134,14 +134,9 @@ public class EnemyMove : MonoBehaviour {
         if (gameObject.tag == "Enemy")
         {
 
-            if (attackMark)
+            if (!anim.GetCurrentAnimatorStateInfo(0).IsName("Attack_DeepOnes"))
             {
-                attackTrigger.enabled = true;
-            }
-
-            if (!attackMark)
-            {
-                attackTrigger.enabled = false;
+                attackTrigger.SetActive(false);
             }
             
             if (range <= minDistance && !idle && !anim.GetBool("Death") == true && Player.transform.position.y >= gameObject.transform.position.y - .2f && Player.transform.position.y <= gameObject.transform.position.y + .2f)
@@ -448,12 +443,15 @@ public class EnemyMove : MonoBehaviour {
 
     private void meleeAttack()
     {
-        attackMark = true;
+        if (controlscript.dead == false)
+        {
+            attackTrigger.SetActive(true);
+        }
     }
 
     private void stopMeleeAttack()
     {
-        attackMark = false;
+        attackTrigger.SetActive(false);
     }
 
     public enum DashState

--- a/Wrath of Cthulhu/Assets/Scripts/Player.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/Player.cs
@@ -180,7 +180,7 @@ public class Player : MonoBehaviour {
             anim.SetFloat("Speed", Mathf.Abs(rb2d.velocity.x) + Mathf.Abs(rb2d.velocity.y));
             anim.SetBool("Shooting", false);
 
-            if (Input.GetKeyDown(KeyCode.R) && ammoScript.countAmmo != 6f) //reload ammo
+            if (Input.GetKeyDown(KeyCode.R) && ammoScript.countAmmo != 12f) //reload ammo
             {
                 anim.SetBool("Reload", true);
             }
@@ -456,7 +456,7 @@ public class Player : MonoBehaviour {
 
     public void reloadEnd()
     {
-        while (ammoScript.countAmmo != 6)
+        while (ammoScript.countAmmo != 12)
         {
             ammoScript.countAmmo += 1f;
         }

--- a/Wrath of Cthulhu/Assets/Scripts/SectionCollider.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/SectionCollider.cs
@@ -27,6 +27,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(22.56f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(28.17f, 5.78f, -10f);
                     playerScript.colliderCount += 1f;
@@ -39,6 +40,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(33.35f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(38.38f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -51,6 +53,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(43.59f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(49.01f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -63,6 +66,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(54.21f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(59.53f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -75,6 +79,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(64.71f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(73.27f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -87,6 +92,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(78.46f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(82.24f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -99,6 +105,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(87.42f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(96.15f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -111,6 +118,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(101.33f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(109.08f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;
@@ -123,6 +131,7 @@ public class SectionCollider : MonoBehaviour {
                 {
                     controlscript.SectionEndCollider = gameObject;
                     gameObject.SetActive(false);
+                    Player.transform.position = new Vector3(gameObject.transform.localPosition.x + .63227f, 3.08f, 0f);
                     controlscript.minCameraPos = new Vector3(114.27f, 1.50f, -10f);
                     controlscript.maxCameraPos = new Vector3(125.23f, 5.80f, -10f);
                     playerScript.colliderCount += 1f;

--- a/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs
@@ -9,11 +9,18 @@ public class Ammo : MonoBehaviour {
 
     private void Start()
     {
-        countAmmo = 6f;        
+        countAmmo = 12f;        
     }
     // Update is called once per frame
     void Update()
     {
-        GetComponent<Text>().text = countAmmo + " / A m m o";
+        if (countAmmo <= 9f)
+        {
+            GetComponent<Text>().text = " " + countAmmo + " / A m m o";
+        }
+        else
+        {
+            GetComponent<Text>().text = countAmmo + " / A m m o";
+        }
     }
 }

--- a/Wrath of Cthulhu/Assets/Scripts/enemyAttackTrigger.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/enemyAttackTrigger.cs
@@ -4,11 +4,24 @@ using UnityEngine;
 
 public class enemyAttackTrigger : MonoBehaviour {
 
+    private GameObject Player;
+    Player controlscript;
+    private Animator anim;
+    private Animator enemyAnim;
+
+    private void Start()
+    {
+        Player = GameObject.FindWithTag("Player");
+        controlscript = Player.GetComponent<Player>();
+        anim = Player.GetComponent<Animator>();
+        enemyAnim = transform.parent.gameObject.GetComponent<Animator>();
+    }
+
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.gameObject.tag == "Player" && transform.parent.gameObject.GetComponent<EnemyMove>().health > 0f)
+        if (collision.gameObject.tag == "Player" && transform.parent.gameObject.GetComponent<EnemyMove>().health > 0f && !anim.GetCurrentAnimatorStateInfo(0).IsName("Damage_Mark") && controlscript.sounds[1].isPlaying == false)
         {
-            transform.parent.gameObject.GetComponent<EnemyMove>().Damage();
+          transform.parent.gameObject.GetComponent<EnemyMove>().Damage();
         }
     }
 }


### PR DESCRIPTION
MAJOR BUG FIXED
* On successful collision with a section collider, if you moved Mark slowly towards the new scene, you could move him back to a previous scene while the camera re-positioned for the 
  new scene. This made it impossible to see Mark. It's now fixed, and on collision with a section collider, it immediately closes so Mark cannot ever turn back. 
  
MAJOR BUG FIXED
* Enemy attack trigger was always active! The intention was to keep it disabled until an enemy attacks Mark, and then disable it otherwise. It works as intended now.
* Due to the issue above, a trigger event would constantly fire and damage Mark multiple times, even if the enemy wasn't attacking. You would see Mark's health
  drain extremely fast
* After getting hit by an enemy and quickly turning around to run away, Mark would still get further damaged about 1-2 times, even if the enemy only attacked once. Issue is now fixed.

Polishing:
* Increased ammo capacity to 12 (previous was 6, had to reload too often)