### PR TITLE
Juan's List of To-Dos

### DIFF
--- a/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
@@ -1460,8 +1460,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 278, y: -158}
-  m_SizeDelta: {x: 318.42, y: 96.6}
+  m_AnchoredPosition: {x: 297.3, y: -158}
+  m_SizeDelta: {x: 210.82, y: 96.6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1736242073
 MonoBehaviour:

--- a/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
@@ -4569,7 +4569,7 @@ Transform:
   m_Children:
   - {fileID: 408186884}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &291277039
 Rigidbody2D:
@@ -9952,6 +9952,16 @@ Prefab:
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[43].y
       value: 0.037190534
       objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -822259951
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: -2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 264076073226a07449b08c733efa85d4, type: 2}
   m_IsPrefabParent: 0
@@ -11836,6 +11846,16 @@ Prefab:
         type: 2}
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[43].y
       value: 0.037190534
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -822259951
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 264076073226a07449b08c733efa85d4, type: 2}
@@ -17631,6 +17651,16 @@ Prefab:
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[43].y
       value: 0.037190534
       objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -822259951
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: -2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 264076073226a07449b08c733efa85d4, type: 2}
   m_IsPrefabParent: 0
@@ -19041,7 +19071,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 465656, guid: b046278bb9b6e104790392b566667ba5, type: 2}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 11475408, guid: b046278bb9b6e104790392b566667ba5, type: 2}
       propertyPath: Camera
@@ -24012,6 +24042,16 @@ Prefab:
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[43].y
       value: 0.037190534
       objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -822259951
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: -2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 264076073226a07449b08c733efa85d4, type: 2}
   m_IsPrefabParent: 0
@@ -25648,6 +25688,16 @@ Prefab:
         type: 2}
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[43].y
       value: 0.037190534
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -822259951
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 264076073226a07449b08c733efa85d4, type: 2}
@@ -31591,6 +31641,16 @@ Prefab:
         type: 2}
       propertyPath: m_Points.m_Paths.Array.data[0].Array.data[43].y
       value: 0.037190534
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -822259951
+      objectReference: {fileID: 0}
+    - target: {fileID: 212256198402479746, guid: 264076073226a07449b08c733efa85d4,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: -2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 264076073226a07449b08c733efa85d4, type: 2}

--- a/Wrath of Cthulhu/Assets/Scripts/BulletFire.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/BulletFire.cs
@@ -21,8 +21,8 @@ public class BulletFire : MonoBehaviour
     {
         Player = GameObject.FindWithTag("Player").gameObject;
         anim = Player.GetComponent<Animator>();
-        enemyDamage = 25f;
-        enemyMadness = 10f;
+        enemyDamage = 35f;
+        enemyMadness = 15f;
         restrictCurrency = true;
         playerBulletForce = 500f;
         controlscript = Player.GetComponent<Player>();
@@ -124,6 +124,9 @@ public class BulletFire : MonoBehaviour
                     anim.SetBool("Blink", true);
                     Destroy(gameObject);
                 }
+                break;
+
+            case "Currency":
                 break;
 
             default:

--- a/Wrath of Cthulhu/Assets/Scripts/EnemyMove.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/EnemyMove.cs
@@ -330,7 +330,7 @@ public class EnemyMove : MonoBehaviour {
         {
             if (playerAnim.GetBool("Blink") == false)
             {
-                Player.GetComponent<Player>().playerHealth -= 15f;
+                Player.GetComponent<Player>().playerHealth -= 20f;
                 Player.GetComponent<Player>().playerMadness += enemyMadness;
                 controlscript.sounds[1].Play();
                 Player.GetComponent<Animator>().SetBool("Hit", true);
@@ -361,21 +361,18 @@ public class EnemyMove : MonoBehaviour {
         enposition = gameObject.GetComponent<EnemyMove>().transform.position;
         Destroy(gameObject);
         randomIndex = Random.Range(1f, 100f);
-        if (false&&randomIndex <= 60f && randomIndex >= 1f) ///THIS IF NEVER SUCCEEDS BECAUSE THE ITEMS DROPPED BY THE ENEMY ARE LIMITED TO CURRENCY
+        /*if (false&&randomIndex <= 60f && randomIndex >= 1f) ///THIS IF NEVER SUCCEEDS BECAUSE THE ITEMS DROPPED BY THE ENEMY ARE LIMITED TO CURRENCY
         {
             //itemIndex = Random.Range(0, collision.gameObject.GetComponent<EnemyMove>().items.Length - 1);
             itemIndex = Random.Range(3, gameObject.GetComponent<EnemyMove>().items.Length);
             GameObject coin = Instantiate(gameObject.GetComponent<EnemyMove>().items[itemIndex], enposition, Quaternion.identity);
             Destroy(coin, 5);
-        }
-
-        else
-        {
-            itemIndex = Random.Range(0, gameObject.GetComponent<EnemyMove>().items.Length - 2);
-            GameObject coin = Instantiate(gameObject.GetComponent<EnemyMove>().items[itemIndex], enposition, Quaternion.identity);
-            Destroy(coin, 5);
-        }
-        Player.GetComponent<Player>().enemiesKilled++;
+        }*/
+       itemIndex = Random.Range(0, gameObject.GetComponent<EnemyMove>().items.Length);
+       GameObject coin = Instantiate(gameObject.GetComponent<EnemyMove>().items[itemIndex], enposition, Quaternion.identity);
+       Destroy(coin, 5);
+      
+       Player.GetComponent<Player>().enemiesKilled++;
     }
 
     void InstantiateBullet()

--- a/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/Ammo.cs
@@ -16,11 +16,11 @@ public class Ammo : MonoBehaviour {
     {
         if (countAmmo <= 9f)
         {
-            GetComponent<Text>().text = "   " + countAmmo + " / A m m o";
+            GetComponent<Text>().text = "   " + countAmmo + " / 12";
         }
         else
         {
-            GetComponent<Text>().text = countAmmo + " / A m m o";
+            GetComponent<Text>().text = countAmmo + " / 12";
         }
     }
 }


### PR DESCRIPTION
* Range Enemy bullets now go through currency on the floor
* Range Enemy damage increased from 25 to 35, madness increased from 10 to 15
* Enemy dash damage increased from 15 to 20
* Weapon Shop issue fixed (Mark now appears on top of the design)
* All 3 currency images randomly drop now instead of 1
* Ammo UI shows "ammoCount / maxAmmo" instead of "ammoCount / Ammo"