### PR TITLE
Fixed Bullet Spread Bug

### DIFF
--- a/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/PlayerMovement.unity
@@ -4626,7 +4626,6 @@ MonoBehaviour:
   revive: 0
   reviveImage: {fileID: 0}
   sounds: []
-  gameAudio: {fileID: 1883274627}
   pauseGame: 0
   item: none
   maxSpeed: 0.5
@@ -17202,10 +17201,6 @@ PolygonCollider2D:
       - {x: 0.16873741, y: 0.20425272}
       - {x: 0.15372157, y: 0.28510714}
       - {x: 0.09821868, y: 0.32625437}
---- !u!1 &1034014523 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 191326, guid: b046278bb9b6e104790392b566667ba5, type: 2}
-  m_PrefabInternal: {fileID: 1214920029}
 --- !u!1 &1037253542
 GameObject:
   m_ObjectHideFlags: 0
@@ -23255,7 +23250,7 @@ Transform:
   m_LocalScale: {x: 3.6062298, y: 3.6062293, z: 3.6062293}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1460905572
 GameObject:
@@ -30776,115 +30771,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1880628582}
---- !u!1 &1883274627
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1883274629}
-  - component: {fileID: 1883274628}
-  m_Layer: 0
-  m_Name: Game Sound
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!82 &1883274628
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1883274627}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 5acd3b3164ff48f44ab72fc8c5222b1d, type: 3}
-  m_PlayOnAwake: 0
-  m_Volume: 0.2
-  m_Pitch: 1
-  Loop: 1
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    - serializedVersion: 2
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
---- !u!4 &1883274629
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1883274627}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.0426507, y: 3.8979805, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1884586658
 GameObject:
   m_ObjectHideFlags: 0
@@ -32189,8 +32075,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   boss: {fileID: 1451423753}
-  player: {fileID: 291277035}
-  rain: {fileID: 1034014523}
 --- !u!4 &1985183236 stripped
 Transform:
   m_PrefabParentObject: {fileID: 4114682698746526, guid: 74838ef35bb1d5847a09485e6ebc4936,

--- a/Wrath of Cthulhu/Assets/Scripts/Player.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/Player.cs
@@ -54,7 +54,6 @@ public class Player : MonoBehaviour {
 
     //Audio
     public AudioSource[] sounds;
-    public GameObject gameAudio;
 
     //Player variables
     public bool pauseGame;
@@ -156,11 +155,6 @@ public class Player : MonoBehaviour {
     {
         markShooting = false;
 
-        if (gameOverPanel.activeSelf)
-        {
-            GameObject.FindGameObjectWithTag("Music").GetComponent<MainMenuMusic>().stopGameAudio();
-        }
-
         if (gamePlayPanel.activeSelf)
         {
             Time.timeScale = 0f;
@@ -232,7 +226,7 @@ public class Player : MonoBehaviour {
                 anim.SetBool("Reload", true);
             }
 
-            if (Input.GetKeyDown(KeyCode.Semicolon) && !anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shotgun == true && ammoScript.countAmmo >= 3f)
+            if (Input.GetKeyDown(KeyCode.Semicolon) && !anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shotgun == true && ammoScript.countAmmo > 0f)
             {
                 anim.SetBool("Shooting", true);
                 shootOnce = true;
@@ -344,13 +338,22 @@ public class Player : MonoBehaviour {
 
             if (anim.GetCurrentAnimatorStateInfo(0).IsName("Shoot_Mark") && shootOnce && shotgun == true)
             {
-                GameObject bullet1 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
-                bullet1.transform.Rotate(0f, 0f, 10f);
-                GameObject bullet2 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
-                bullet2.transform.Rotate(0f, 0f, 0f);
-                GameObject bullet3 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
-                bullet3.transform.Rotate(0f, 0f, -10f);
-                ammoScript.countAmmo -= 3f;
+                if (ammoScript.countAmmo >= 3f)
+                {
+                    GameObject bullet1 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
+                    bullet1.transform.Rotate(0f, 0f, 10f);
+                    GameObject bullet2 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
+                    bullet2.transform.Rotate(0f, 0f, 0f);
+                    GameObject bullet3 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
+                    bullet3.transform.Rotate(0f, 0f, -10f);
+                    ammoScript.countAmmo -= 3f;
+                }
+                
+                else
+                {
+                    Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
+                    ammoScript.countAmmo -= 1f;
+                }
                 //Transform newBullet = Instantiate(bullet.transform, spawnPoint.position, Quaternion.identity) as Transform;
                 //newBullet.parent = transform;
                 markShooting = true;
@@ -473,8 +476,8 @@ public class Player : MonoBehaviour {
 
         if (dead == true)
         {
-            gameAudio.GetComponent<AudioSource>().Stop();
             gameOverPanel.SetActive(true);
+            GameObject.FindGameObjectWithTag("Music").GetComponent<MainMenuMusic>().stopGameAudio();
         }
     }
 

--- a/Wrath of Cthulhu/Assets/Scripts/spawnBoss.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/spawnBoss.cs
@@ -5,21 +5,18 @@ using UnityEngine;
 public class spawnBoss : MonoBehaviour {
 
     public GameObject boss;
-    public GameObject player;
-    public GameObject rain;
-    private Player controlPlayerScript;
+
 
     private void Start()
     {
         boss.SetActive(false);
-        controlPlayerScript = player.GetComponent<Player>();
     }
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.gameObject.tag == "Player")
         {
             boss.SetActive(true);
-            controlPlayerScript.gameAudio.GetComponent<AudioSource>().Stop();
+            GameObject.FindGameObjectWithTag("Music").GetComponent<MainMenuMusic>().stopGameAudio();
         }
     }
 }


### PR DESCRIPTION
* Boss spawn point was not turning off game audio because of the new way of playing audio (fixed now)
* Mark will now shoot 1 bullet if he has less than 3 bullets left, and the bullet spread upgrade has been purchased. After reloading, he will shoot 3 bullets. 