### PR TITLE
Fixed Bullet Freezing Bug

### DIFF
--- a/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
+++ b/Wrath of Cthulhu/Assets/Scenes/MainMenu.unity
@@ -1922,7 +1922,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c97b45ec42df45f6b014fc121fa2324, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  count: 0
+  count: 5
 --- !u!114 &1804639604
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Wrath of Cthulhu/Assets/Scripts/BulletFire.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/BulletFire.cs
@@ -57,6 +57,8 @@ public class BulletFire : MonoBehaviour
                         GetComponent<Rigidbody2D>().AddForce(-transform.right * playerBulletForce);
                     }
 
+                    controlscript.lockTransform = false;
+
                 }
                 break;
 

--- a/Wrath of Cthulhu/Assets/Scripts/Player.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/Player.cs
@@ -70,6 +70,7 @@ public class Player : MonoBehaviour {
 	public bool call;  //determines if blinking
 	public bool canPause;
 	public bool reviving; //Determines if Player has died and is coming back
+    public bool lockTransform; 
 
 	public GameObject moveForward;
 	public Image GoImage;
@@ -111,6 +112,7 @@ public class Player : MonoBehaviour {
 		colliderCount = 0f;
 		speedCount = 0f;
 		reviving = false;
+        lockTransform = false;
 
 		ItemUI = GameObject.Find("Item");
 		reviveImage = ItemUI.transform.Find ("ReviveUI").gameObject;
@@ -348,12 +350,14 @@ public class Player : MonoBehaviour {
                     bullet2.transform.Rotate(0f, 0f, 0f);
                     GameObject bullet3 = (GameObject)Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
                     bullet3.transform.Rotate(0f, 0f, -10f);
+                    lockTransform = true;
                     ammoScript.countAmmo -= 3f;
                 }
                 
                 else
                 {
                     Instantiate(bullet, spawnPoint.position, spawnPoint.rotation);
+                    lockTransform = true;
                     ammoScript.countAmmo -= 1f;
                 }
                 //Transform newBullet = Instantiate(bullet.transform, spawnPoint.position, Quaternion.identity) as Transform;
@@ -370,6 +374,7 @@ public class Player : MonoBehaviour {
                 //newBullet.parent = transform;
                 markShooting = true;
                 shootOnce = false;
+                lockTransform = true;
             }
 
             if (playerHealth <= 0f) {
@@ -496,14 +501,22 @@ public class Player : MonoBehaviour {
 		if (!dead && !reviving) {
 			if (Input.GetKey (KeyCode.A)) {
 				rb2d.AddForce (Vector3.left * speed);
-                transform.localScale = new Vector3(-2f, 2f, 1f);
-                left = true;
+
+                if (lockTransform == false)
+                {
+                    transform.localScale = new Vector3(-2f, 2f, 1f);
+                    left = true;
+                }
             }
 
-			if (Input.GetKey (KeyCode.D)) {
+            if (Input.GetKey(KeyCode.D)) {
 				rb2d.AddForce (Vector3.right * speed);
-                transform.localScale = new Vector3(2f, 2f, 1f);
-                left = false;
+
+                if (lockTransform == false)
+                {
+                    transform.localScale = new Vector3(2f, 2f, 1f);
+                    left = false;
+                }
             }
 
             if (Input.GetKey (KeyCode.W)) {

--- a/Wrath of Cthulhu/Assets/Scripts/UI/GameOver.meta
+++ b/Wrath of Cthulhu/Assets/Scripts/UI/GameOver.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 08b0f9f894e9f495991a6f35c09272e3
-folderAsset: yes
-timeCreated: 1510257241
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Wrath of Cthulhu/ProjectSettings/ProjectVersion.txt
+++ b/Wrath of Cthulhu/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.1.1f1
+m_EditorVersion: 2017.1.0f3


### PR DESCRIPTION
Mark can't transform left or right between the time a bullet is created to when force is added to the bullet. This prevents the bullet freezing bug. 