### PR TITLE
Fixed Revive Death Glitch

### DIFF
--- a/Wrath of Cthulhu/Assets/Scripts/Player.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/Player.cs
@@ -578,7 +578,12 @@ public class Player : MonoBehaviour {
             anim.SetBool("Dead", true);
         }
 
-        else
+        else if (playerMadness >= 100f && !revive)
+        {
+            anim.SetBool("Dead", true);
+        }
+
+        else if (!reviving)
         {
             anim.SetBool("Blink", true);
         }

--- a/Wrath of Cthulhu/Assets/Scripts/UI-WeaponShop/WeaponButton.cs
+++ b/Wrath of Cthulhu/Assets/Scripts/UI-WeaponShop/WeaponButton.cs
@@ -111,7 +111,7 @@ public class WeaponButton : MonoBehaviour
 					if (boughtShotgun == false) { // if shotgun upgrade and havent bought yet
 						pagescript.count -= controlscript.weapons [weaponNumber].cost;
 						controlscript.latestBuy = weaponNumber;
-                        controlscript.bulletDamage = 60f + controlscript.damageUpgrade;
+                        controlscript.bulletDamage = 75f + controlscript.damageUpgrade;
 						boughtShotgun = true; //now bought
 						controlscript.shotgun = true;
 					} 


### PR DESCRIPTION
* Mark would show a blink animation right before dying if he had a revive. That problem is now fixed.
* Bullet spread upgrade now starts at 75 damage (60 was too less and barely did any damage)